### PR TITLE
Ajout de l'autofill pour le champ "lieunaissance"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -128,7 +128,7 @@
                         id="field-lieunaissance"
                         name="lieunaissance"
                         aria-invalid="false"
-                        autocomplete="off"
+                        autocomplete="section-birthplace address-level2"
                         placeholder="Lyon"
                         required
                     >


### PR DESCRIPTION
Ajout d'un [autofill-scope](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-scope) au champ de saisie du lieu de naissance, pour éviter la re-saisie au retour à la page précédente.